### PR TITLE
Add ESP32 drainage code fix slide

### DIFF
--- a/_posts/0000-01-02-esp32-pullup.md
+++ b/_posts/0000-01-02-esp32-pullup.md
@@ -1,0 +1,10 @@
+---
+layout: slide
+title: "ESP32: entradas, pull-ups e LEDs"
+---
+
+- GPIO 34/35 são somente entrada e **não têm** pull-up/pull-down internos; para usar botões simples, prefira pinos como 21/22/23 com `INPUT_PULLUP` ou adicione resistores externos de 10 kΩ a VCC (pull-up) e ligue o botão ao GND.
+- Se optar por `INPUT_PULLUP`, conecte um lado do botão ao pino e o outro ao GND; no código, use `pinMode(pino, INPUT_PULLUP)` e considere o botão **ativo em LOW**.
+- Saídas para LEDs devem ficar apenas em `pinMode(pin, OUTPUT)`; não ative pull-ups em saídas e mantenha resistores de ~220 Ω em série com cada LED.
+- Para testar no Wokwi: com `INPUT_PULLUP`, os LEDs devem acender quando o botão for pressionado (nível LOW). Se usar pull-up externo, deixe o botão desconectado (aberto) para ler HIGH e pressione para forçar LOW.
+- Se os botões não mudam o estado, verifique a direção da ligação (lado do botão para GND), se o pino realmente suporta `INPUT_PULLUP`, e se não há curto entre VCC e GND nos leds/resistores.

--- a/_posts/0000-01-03-esp32-drenagem-fix.md
+++ b/_posts/0000-01-03-esp32-drenagem-fix.md
@@ -1,0 +1,25 @@
+---
+layout: slide
+title: "ESP32: correção rápida do código de drenagem"
+---
+
+- **Use pinos com `INPUT_PULLUP` real**: troque os sensores para GPIO 21 e 22 (ou 18/19). Eles aceitam pull-up interno; 34/35 não e 32/33 podem falhar sem resistor externo.
+- **Fiação ativa em LOW**: botão entre pino e GND; deixe o outro terminal do botão livre (pull-up interno mantém HIGH). Sem resistor externo, não ligue o botão ao 3V3.
+- **Ajuste os pinos no código**:
+  ```cpp
+  const int PIN_SENSOR_INF = 21;
+  const int PIN_SENSOR_SUP = 22;
+  ...
+  pinMode(PIN_SENSOR_INF, INPUT_PULLUP);
+  pinMode(PIN_SENSOR_SUP, INPUT_PULLUP);
+  ```
+- **Inicialize os estados logo após o `pinMode`** para evitar começar travado:
+  ```cpp
+  sInf.estadoAtual = (digitalRead(PIN_SENSOR_INF) == LOW);
+  sSup.estadoAtual = (digitalRead(PIN_SENSOR_SUP) == LOW);
+  sInf.ultimaLeituraFisica = sInf.estadoAtual ? LOW : HIGH;
+  sSup.ultimaLeituraFisica = sSup.estadoAtual ? LOW : HIGH;
+  sInf.tempoMudanca = sSup.tempoMudanca = millis();
+  ```
+- **No Wokwi**, ligue cada botão entre o pino (21/22) e GND; remova qualquer ligação ao 3V3. Se precisar manter 32/33 ou 34/35, adicione um resistor de 10 kΩ para VCC (pull-up externo) e mantenha o botão para GND.
+- **Teste esperado**: ao manter os dois botões pressionados (LOW), LEDs verde/azul acesos e bomba/rele ligados; soltando o inferior (subindo a boia), o sistema desliga e imprime o relatório.


### PR DESCRIPTION
## Summary
- add a slide with wiring and code adjustments to fix the ESP32 drainage sketch when using internal pull-ups
- document initial sensor state initialization to avoid stuck startup in Wokwi

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246f797fa08331bd13c37bff3428ec)