### PR TITLE
Add notebook for Brazilian stock analysis

### DIFF
--- a/notebooks/analise_b3_ia.ipynb
+++ b/notebooks/analise_b3_ia.ipynb
@@ -1,0 +1,404 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Análise Completa de Ações Brasileiras com IA\n",
+    "\n",
+    "Notebook pronto para rodar localmente que baixa dados históricos da B3 via Yahoo Finance (yfinance), oferece alternativa offline via arquivos COTAHIST, calcula indicadores técnicos, compara múltiplos tickers e ilustra uma previsão simples com ARIMA. Os gráficos usam Plotly para interatividade dentro do Jupyter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dependências\n",
+    "\n",
+    "Execute a célula abaixo uma única vez no ambiente local para instalar os pacotes necessários (ou adapte para um `requirements.txt`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remova o comentário para instalar dependências no ambiente local\n",
+    "# %pip install pandas numpy yfinance plotly statsmodels requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import plotly.express as px\n",
+    "import plotly.graph_objects as go\n",
+    "import requests\n",
+    "import yfinance as yf\n",
+    "from statsmodels.tsa.arima.model import ARIMA\n",
+    "\n",
+    "pd.options.display.float_format = \"{:.2f}\".format"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Utilitários de entrada\n",
+    "\n",
+    "- `normalizar_ticker`: adiciona o sufixo `.SA` quando ausente para B3.\n",
+    "- `selecionar_tickers`: aceita lista manual ou busca tickers por setor via BRAPI (quando houver conexão). Em cenários offline, usa um mapa local mínimo para alguns setores populares."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BRAPI_LIST_URL = \"https://brapi.dev/api/quote/list\"\n",
+    "\n",
+    "LOCAL_SECTORS = {\n",
+    "    \"energia\": [\"PETR4\", \"PRIO3\", \"RECV3\"],\n",
+    "    \"mineracao\": [\"VALE3\", \"CSNA3\", \"GGBR4\"],\n",
+    "    \"financeiro\": [\"ITUB4\", \"BBDC4\", \"BBAS3\"],\n",
+    "    \"varejo\": [\"LREN3\", \"MGLU3\", \"AMER3\"],\n",
+    "}\n",
+    "\n",
+    "def normalizar_ticker(ticker: str) -> str:\n",
+    "    ticker = ticker.strip().upper()\n",
+    "    return ticker if ticker.endswith(\".SA\") else f\"{ticker}.SA\"\n",
+    "\n",
+    "def selecionar_tickers(tickers=None, setor=None, limite: int = 5):\n",
+    "    if tickers:\n",
+    "        return [normalizar_ticker(t) for t in tickers]\n",
+    "    if not setor:\n",
+    "        raise ValueError(\"Informe tickers manualmente ou um setor para busca.\")\n",
+    "\n",
+    "    setor_lower = setor.lower()\n",
+    "    params = {\"search\": \"\", \"limit\": limite, \"sector\": setor_lower}\n",
+    "    try:\n",
+    "        response = requests.get(BRAPI_LIST_URL, params=params, timeout=10)\n",
+    "        response.raise_for_status()\n",
+    "        data = response.json().get(\"stocks\", [])\n",
+    "        if data:\n",
+    "            return [normalizar_ticker(item[\"stock\"] + \".SA\") for item in data[:limite]]\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "\n",
+    "    locais = LOCAL_SECTORS.get(setor_lower)\n",
+    "    if locais:\n",
+    "        return [normalizar_ticker(t) for t in locais[:limite]]\n",
+    "    raise ValueError(f\"Nenhum ticker encontrado para o setor '{setor}'.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Coleta de dados de preços\n",
+    "\n",
+    "- `baixar_historico_yf`: usa yfinance para 2 anos de dados (ajuste automático para o sufixo `.SA`).\n",
+    "- `baixar_cotahist_b3`: download opcional dos arquivos oficiais COTAHIST e parsing para DataFrame (útil para uso totalmente offline). Informe anos como `[2023, 2024]`, por exemplo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "COTAHIST_URL = \"https://bvmf.bmfbovespa.com.br/InstDados/SerHist/COTAHIST_AAAA.ZIP\"\n",
+    "\n",
+    "def baixar_historico_yf(tickers, periodo: str = \"2y\"):\n",
+    "    historicos = {}\n",
+    "    for t in tickers:\n",
+    "        ticker_fmt = normalizar_ticker(t)\n",
+    "        hist = yf.Ticker(ticker_fmt).history(period=periodo, auto_adjust=False)\n",
+    "        if hist.empty:\n",
+    "            continue\n",
+    "        hist = hist.rename(columns=str.capitalize).reset_index().rename(columns={\"Date\": \"Data\"})\n",
+    "        historicos[ticker_fmt] = hist\n",
+    "    return historicos\n",
+    "\n",
+    "def _parse_cotahist_file(conteudo: bytes):\n",
+    "    linhas = conteudo.decode(\"latin-1\").splitlines()\n",
+    "    registros = []\n",
+    "    for linha in linhas:\n",
+    "        if not linha.startswith(\"00\") and len(linha) >= 245:\n",
+    "            data = pd.to_datetime(linha[2:10], format=\"%Y%m%d\")\n",
+    "            ticker = linha[12:24].strip()\n",
+    "            preco_abertura = float(linha[56:69]) / 100\n",
+    "            preco_maximo = float(linha[69:82]) / 100\n",
+    "            preco_minimo = float(linha[82:95]) / 100\n",
+    "            preco_medio = float(linha[95:108]) / 100\n",
+    "            preco_fechamento = float(linha[108:121]) / 100\n",
+    "            volume = int(linha[170:188])\n",
+    "            registros.append({\n",
+    "                \"Data\": data,\n",
+    "                \"Ticker\": ticker,\n",
+    "                \"Open\": preco_abertura,\n",
+    "                \"High\": preco_maximo,\n",
+    "                \"Low\": preco_minimo,\n",
+    "                \"Close\": preco_fechamento,\n",
+    "                \"Average\": preco_medio,\n",
+    "                \"Volume\": volume,\n",
+    "            })\n",
+    "    return pd.DataFrame(registros)\n",
+    "\n",
+    "def baixar_cotahist_b3(anos):\n",
+    "    frames = []\n",
+    "    for ano in anos:\n",
+    "        url = COTAHIST_URL.replace(\"AAAA\", str(ano))\n",
+    "        resp = requests.get(url, timeout=30)\n",
+    "        resp.raise_for_status()\n",
+    "        frames.append(_parse_cotahist_file(resp.content))\n",
+    "    return pd.concat(frames, ignore_index=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Indicadores técnicos e métricas auxiliares\n",
+    "\n",
+    "- `calcular_indicadores`: cria médias móveis, volatilidade de 30 dias, RSI, retorno diário e acumulado.\n",
+    "- `matriz_correlacao`: correlação de retornos diários entre múltiplos ativos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _calcular_rsi(series: pd.Series, periodo: int = 14):\n",
+    "    delta = series.diff()\n",
+    "    ganhos = delta.clip(lower=0)\n",
+    "    perdas = -delta.clip(upper=0)\n",
+    "    ganho_rol = ganhos.rolling(periodo).mean()\n",
+    "    perda_rol = perdas.rolling(periodo).mean()\n",
+    "    rs = ganho_rol / perda_rol\n",
+    "    rsi = 100 - (100 / (1 + rs))\n",
+    "    return rsi\n",
+    "\n",
+    "def calcular_indicadores(df: pd.DataFrame):\n",
+    "    df = df.copy()\n",
+    "    df[\"Retorno\"] = df[\"Close\"].pct_change()\n",
+    "    df[\"Retorno_Acumulado\"] = (1 + df[\"Retorno\"]).cumprod() - 1\n",
+    "    df[\"MA50\"] = df[\"Close\"].rolling(50).mean()\n",
+    "    df[\"MA200\"] = df[\"Close\"].rolling(200).mean()\n",
+    "    df[\"Volatilidade30\"] = df[\"Retorno\"].rolling(30).std() * math.sqrt(252)\n",
+    "    df[\"RSI14\"] = _calcular_rsi(df[\"Close\"], 14)\n",
+    "    return df\n",
+    "\n",
+    "def matriz_correlacao(historicos):\n",
+    "    retornos = []\n",
+    "    nomes = []\n",
+    "    for ticker, df in historicos.items():\n",
+    "        nomes.append(ticker)\n",
+    "        retornos.append(df.set_index(\"Data\")[\"Close\"].pct_change())\n",
+    "    combinado = pd.concat(retornos, axis=1)\n",
+    "    combinado.columns = nomes\n",
+    "    return combinado.corr()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Projeção simples com ARIMA\n",
+    "\n",
+    "Função utilitária para estimar um ARIMA(5,1,0) na série de fechamento ajustado e projetar 30 dias. Para análises mais robustas, ajuste a ordem e valide resíduos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def prever_arima(series: pd.Series, dias: int = 30):\n",
+    "    serie = series.dropna()\n",
+    "    modelo = ARIMA(serie, order=(5, 1, 0)).fit()\n",
+    "    forecast = modelo.forecast(steps=dias)\n",
+    "    forecast.index = pd.date_range(start=serie.index[-1] + pd.Timedelta(days=1), periods=dias, freq=\"B\")\n",
+    "    return forecast"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Síntese textual de insights\n",
+    "\n",
+    "`gerar_insights` cria um resumo simples combinando desempenho recente, volatilidade e posição das médias móveis para sugerir compra, manutenção ou venda."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gerar_insights(df: pd.DataFrame, ticker: str):\n",
+    "    ultimo = df.dropna().iloc[-1]\n",
+    "    retorno_12m = df.set_index(\"Data\")[\"Close\"].pct_change(252).iloc[-1]\n",
+    "    volatilidade = df[\"Volatilidade30\"].iloc[-1]\n",
+    "    tendencia_alta = ultimo[\"Close\"] > ultimo.get(\"MA200\", np.nan)\n",
+    "    curto_acima_longo = ultimo.get(\"MA50\", np.nan) > ultimo.get(\"MA200\", np.nan)\n",
+    "    rsi = ultimo.get(\"RSI14\", np.nan)\n",
+    "\n",
+    "    recomendacao = \"Manter\"\n",
+    "    if tendencia_alta and curto_acima_longo and rsi < 70:\n",
+    "        recomendacao = \"Comprar\"\n",
+    "    elif not tendencia_alta and rsi > 60:\n",
+    "        recomendacao = \"Vender\"\n",
+    "\n",
+    "    linhas = [\n",
+    "        f\"**{ticker}**\",\n",
+    "        f\"Retorno aproximado em 12m: {retorno_12m:,.1%}\",\n",
+    "        f\"Volatilidade anualizada (30d): {volatilidade:,.1%}\",\n",
+    "        f\"Preço atual vs MA200: {'acima' if tendencia_alta else 'abaixo'}\",\n",
+    "        f\"RSI(14): {rsi:0.1f}\",\n",
+    "        f\"Recomendação sugerida: **{recomendacao}**\",\n",
+    "    ]\n",
+    "    return \"\\n\".join(linhas)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exemplo de uso\n",
+    "\n",
+    "Defina tickers manualmente ou informe um setor (ex.: `\"energia\"`, `\"financeiro\"`). Ajuste o período conforme necessário."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tickers = selecionar_tickers(tickers=[\"PETR4\", \"VALE3\", \"ITUB4\"])\n",
+    "periodo = \"2y\"\n",
+    "\n",
+    "historicos = baixar_historico_yf(tickers, periodo)\n",
+    "print(f\"Foram carregados {len(historicos)} tickers: {list(historicos)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualização e indicadores\n",
+    "\n",
+    "Calcula indicadores para cada ativo e gera gráficos interativos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "historicos_ind = {t: calcular_indicadores(df) for t, df in historicos.items()}\n",
+    "\n",
+    "figs = []\n",
+    "for ticker, df in historicos_ind.items():\n",
+    "    fig = go.Figure()\n",
+    "    fig.add_trace(go.Scatter(x=df[\"Data\"], y=df[\"Close\"], name=\"Fechamento\"))\n",
+    "    fig.add_trace(go.Scatter(x=df[\"Data\"], y=df[\"MA50\"], name=\"MA50\"))\n",
+    "    fig.add_trace(go.Scatter(x=df[\"Data\"], y=df[\"MA200\"], name=\"MA200\"))\n",
+    "    fig.update_layout(title=f\"{ticker} - Preço e Médias\", xaxis_title=\"Data\", yaxis_title=\"Preço (BRL)\")\n",
+    "    figs.append(fig)\n",
+    "figs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corr = matriz_correlacao(historicos)\n",
+    "corr.style.background_gradient(cmap=\"RdBu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Previsão de tendência\n",
+    "\n",
+    "Executa ARIMA para o primeiro ticker disponível e plota a projeção de 30 dias úteis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if historicos_ind:\n",
+    "    primeiro = next(iter(historicos_ind.items()))\n",
+    "    ticker, df = primeiro\n",
+    "    serie = df.set_index(\"Data\")[\"Close\"]\n",
+    "    previsao = prever_arima(serie)\n",
+    "\n",
+    "    fig_prev = go.Figure()\n",
+    "    fig_prev.add_trace(go.Scatter(x=serie.index, y=serie, name=\"Histórico\"))\n",
+    "    fig_prev.add_trace(go.Scatter(x=previsao.index, y=previsao, name=\"ARIMA +30d\"))\n",
+    "    fig_prev.update_layout(title=f\"{ticker} - Projeção ARIMA\", xaxis_title=\"Data\", yaxis_title=\"Preço (BRL)\")\n",
+    "    fig_prev.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Insights e recomendação\n",
+    "\n",
+    "Gera um resumo por ativo combinando tendência, volatilidade e RSI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for ticker, df in historicos_ind.items():\n",
+    "    print(gerar_insights(df, ticker))\n",
+    "    print(\"-\" * 60)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Gerado em 2025-11-29 16:37 UTC"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook for Brazilian stock analysis that downloads B3 data via yfinance or COTAHIST and normalizes tickers
- compute technical indicators, correlation matrices, and ARIMA-based projections with Plotly visualizations
- generate simple textual insights and recommendations for selected tickers or sector-based selections

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b207bc2688331b54f14a126a4cb79)